### PR TITLE
Add barriers to the config file which allows the last chosen on/off setting to remain persistent between game sessions

### DIFF
--- a/src/main/java/xyz/amymialee/visiblebarriers/VisibleConfig.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/VisibleConfig.java
@@ -13,12 +13,18 @@ import java.nio.file.Path;
 
 public class VisibleConfig {
     private static final Path configFile = FabricLoader.getInstance().getConfigDir().resolve("visiblebarriers.json");
+    private static boolean visibleBarrier = false;
     private static boolean visibleAir = false;
     private static boolean hideParticles = true;
     private static boolean sendFeedback = true;
     private static boolean solidLights = false;
     private static float baseZoom = 2.8f;
     private static long forcedTime = 6000;
+
+    public static void setVisibleBarrier(boolean visibleBarrier) {
+        VisibleConfig.visibleBarrier = visibleBarrier;
+        saveConfig();
+    }
 
     public static void setVisibleAir(boolean visibleAir) {
         VisibleConfig.visibleAir = visibleAir;
@@ -41,6 +47,10 @@ public class VisibleConfig {
         if (MinecraftClient.getInstance().world != null) {
             MinecraftClient.getInstance().world.setTimeOfDay(VisibleConfig.getForcedTime());
         }
+    }
+
+    public static boolean isBarrierVisible() {
+        return visibleBarrier;
     }
 
     public static boolean isAirVisible() {
@@ -71,6 +81,7 @@ public class VisibleConfig {
         try {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             JsonObject json = new JsonObject();
+            json.addProperty("visibleBarrier", visibleBarrier);
             json.addProperty("visibleAir", visibleAir);
             json.addProperty("hideParticles", hideParticles);
             json.addProperty("sendFeedback", sendFeedback);
@@ -88,6 +99,12 @@ public class VisibleConfig {
             Gson gson = new Gson();
             String reader = Files.readString(configFile);
             JsonObject data = gson.fromJson(reader, JsonObject.class);
+            if (data.has("visibleBarrier")) {
+                visibleBarrier = data.get("visibleBarrier").getAsBoolean();
+                if(visibleBarrier){
+                    VisibleBarriers.toggleBarriers();
+                }
+            }
             if (data.has("visibleAir")) {
                 visibleAir = data.get("visibleAir").getAsBoolean();
             }

--- a/src/main/java/xyz/amymialee/visiblebarriers/VisibleInput.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/VisibleInput.java
@@ -115,9 +115,11 @@ public class VisibleInput {
                                 })))
                                 //Barriers
                                 .then(ClientCommandManager.literal("barriers").executes(context -> {
+                                    VisibleConfig.setVisibleBarrier(!VisibleConfig.isBarrierVisible());
                                     VisibleBarriers.toggleBarriers();
                                     return 1;
                                 }).then(ClientCommandManager.argument("visible", BoolArgumentType.bool()).executes(context -> {
+                                    VisibleConfig.setVisibleBarrier(BoolArgumentType.getBool(context, "visible"));
                                     VisibleBarriers.toggleBarriers = BoolArgumentType.getBool(context, "visible");
                                     VisibleBarriers.reloadWorldRenderer();
                                     VisibleBarriers.booleanFeedback("visiblebarriers.feedback.barriers", VisibleBarriers.toggleBarriers);
@@ -219,6 +221,19 @@ public class VisibleInput {
                         )
                         //Settings
                         .then(ClientCommandManager.literal("settings")
+                                //Persist Visible Barriers
+                                .then(ClientCommandManager.literal("visiblebarrier").executes(context -> {
+                                    VisibleConfig.setVisibleBarrier(!VisibleConfig.isBarrierVisible());
+                                    VisibleBarriers.toggleBarriers();
+                                    VisibleBarriers.booleanFeedback("visiblebarriers.feedback.barriers", VisibleBarriers.toggleBarriers);
+                                    return 1;
+                                }).then(ClientCommandManager.argument("visible", BoolArgumentType.bool()).executes(context -> {
+                                    VisibleConfig.setVisibleBarrier(BoolArgumentType.getBool(context, "visible"));
+                                    VisibleBarriers.toggleBarriers = BoolArgumentType.getBool(context, "visible");
+                                    VisibleBarriers.reloadWorldRenderer();
+                                    VisibleBarriers.booleanFeedback("visiblebarriers.feedback.barriers", VisibleBarriers.toggleBarriers);
+                                    return 1;
+                                })))
                                 //Visible Air
                                 .then(ClientCommandManager.literal("visibleair").executes(context -> {
                                     VisibleConfig.setVisibleAir(!VisibleConfig.isAirVisible());

--- a/src/main/java/xyz/amymialee/visiblebarriers/VisibleInput.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/VisibleInput.java
@@ -61,6 +61,19 @@ public class VisibleInput {
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             if (keyBindingVisibility.wasPressed()) {
                 VisibleBarriers.toggleVisible();
+                //if vis is determined to be false/off and barriers are still true/on, turn the barriers off again
+                if (!VisibleBarriers.isVisibilityEnabled() && VisibleBarriers.areBarriersEnabled()){
+                    VisibleBarriers.toggleBarriers(); //toggle barriers back off again
+                }
+
+                //if vis is true make sure to double check that config has barriers as true
+                if (VisibleBarriers.isVisibilityEnabled()){
+                    VisibleConfig.setVisibleBarrier(true);
+                }
+                //if vis is false make sure to double check that config has barriers as false
+                if (!VisibleBarriers.isVisibilityEnabled()){
+                    VisibleConfig.setVisibleBarrier(false);
+                }
             }
             if (keyBindingBarriers.wasPressed()) {
                 VisibleBarriers.toggleBarriers();


### PR DESCRIPTION
Yeah so it now saves your barrier setting between sessions using the config file. Feel free to give this a test. I haven't seen any issues with this implementation from my own testing, but of course check it and/or clean it up if needed

Basically all methods of swapping barrier on/off now write to config and load from config on game launch:
- Using the 'b' hotkey
- Using `/visiblebarriers visibility barriers true/false`
- Using `/visiblebarriers settings visiblebarrier true/false`