### PR TITLE
fix broken images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ It also has several other features, such as a zoom keybind, fullbright, and the 
     <tr>
         <th>
             <a href="http://discord.amymialee.xyz">
-                <img src="https://edent.github.io/SuperTinyIcons/images/svg/discord.svg" width="150" height="150" alt="">
+                <img src="https://github.com/user-attachments/assets/9009250b-20e1-4985-a081-9760ffff93aa" width="150" height="150" alt="">
             </a>
         </th>
         <th>
             <a href="https://www.curseforge.com/minecraft/mc-mods/visiblebarriers">
-                <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/available/curseforge_vector.svg" width="150" height="150" alt="">
+                <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/available/curseforge_vector.svg" width="200" height="200" alt="">
             </a>
         </th>
         <th>
             <a href="https://modrinth.com/mod/visiblebarriers">
-                <img src="https://docs.modrinth.com/img/logo.svg" width="150" height="150" alt="">
+                <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/available/modrinth_vector.svg" width="200" height="200" alt="">
             </a>
         </th>
         <th>

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ It also has several other features, such as a zoom keybind, fullbright, and the 
     <tr>
         <th>
             <a href="http://discord.amymialee.xyz">
-                <img src="https://cdn.discordapp.com/attachments/793182374410059887/924000460292104282/3437c10597c1526c3dbd98c737c2bcae.svg" width="150" height="150" alt="">
+                <img src="https://edent.github.io/SuperTinyIcons/images/svg/discord.svg" width="150" height="150" alt="">
             </a>
         </th>
         <th>
             <a href="https://www.curseforge.com/minecraft/mc-mods/visiblebarriers">
-                <img src="https://cdn.discordapp.com/attachments/793182374410059887/923990008543711282/anvil.svg" width="150" height="150" alt="">
+                <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/available/curseforge_vector.svg" width="150" height="150" alt="">
             </a>
         </th>
         <th>


### PR DESCRIPTION
The discord and curseforge images in the readme were showing as broken, so I updated them. I also changed the modrinth one to match the curseforge one (I didn't want to steal a curseforge image). Fixes #76 