### PR TITLE
fix: crash when an invisible entity is non-living

### DIFF
--- a/src/main/java/xyz/amymialee/visiblebarriers/util/FloatyRenderer.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/util/FloatyRenderer.java
@@ -43,7 +43,7 @@ public class FloatyRenderer {
         state.standingEyeHeight = entity.getStandingEyeHeight();
         state.positionOffset = null;
         state.squaredDistanceToCamera = MinecraftClient.getInstance().cameraEntity.squaredDistanceTo(entity);
-        this.itemModelManager.clearAndUpdate(state.itemRenderState, stack, ItemDisplayContext.GROUND, entity.getWorld(), (LivingEntity) entity, entity.getId());
+        this.itemModelManager.clearAndUpdate(state.itemRenderState, stack, ItemDisplayContext.GROUND, entity.getWorld(), entity instanceof LivingEntity living ? living : null, entity.getId());
         state.renderedAmount = 1;
         matrixStack.push();
         matrixStack.translate(0.0D, entity.getHeight() / 2, 0.0D);


### PR DESCRIPTION
This fixes a crash when an entity is non-living and doesnt provide an entity context to the item then.

closes #90